### PR TITLE
flatpak: Use GIT_CLONE_BRANCH instead of GIT_BRANCH

### DIFF
--- a/build-flatpak.sh
+++ b/build-flatpak.sh
@@ -4,11 +4,11 @@ set -x
 rm -rf files var metadata export build
 
 BRANCH=${BRANCH:-master}
-GIT_BRANCH=${GIT_BRANCH:-HEAD}
+GIT_CLONE_BRANCH=${GIT_CLONE_BRANCH:-HEAD}
 
 sed \
   -e "s|@BRANCH@|${BRANCH}|g" \
-  -e "s|@GIT_BRANCH@|${GIT_BRANCH}|g" \
+  -e "s|@GIT_CLONE_BRANCH@|${GIT_CLONE_BRANCH}|g" \
   com.endlessm.CompanionAppService.json.in \
   > com.endlessm.CompanionAppService.json
 

--- a/com.endlessm.CompanionAppService.json.in
+++ b/com.endlessm.CompanionAppService.json.in
@@ -49,7 +49,7 @@
                 {
                     "type": "git",
                     "path": ".",
-                    "branch": "@GIT_BRANCH@"
+                    "branch": "@GIT_CLONE_BRANCH@"
                 }
             ]
         }


### PR DESCRIPTION
On jenkins, GIT_BRANCH is set to the remote ref. We can't clone a remote
ref from a local repo. Use a separate GIT_CLONE_BRANCH variable that
won't collide with jenkins.

https://phabricator.endlessm.com/T20243