### PR TITLE
eosocompanion: Don't include the error prefix in the strigified error

### DIFF
--- a/eoscompanion/main.py
+++ b/eoscompanion/main.py
@@ -36,7 +36,7 @@ def serialize_error_as_json_object(domain, code, detail={}):
     '''Serialize a GLib.Error as a JSON object.'''
     return {
         'domain': GLib.quark_to_string(domain),
-        'code': code.value_name,
+        'code': code.value_nick.replace('-', '_').upper(),
         'detail': detail
     }
 


### PR DESCRIPTION
The easiest way to do this that is domain independent is to just take
the nick, replace '-' with '_' and upper() it. This is consistent
with what we have in the design document.

https://phabricator.endlessm.com/T20317