### PR TITLE
socket: Check correct file for eos-companion-app.socket

### DIFF
--- a/data/eos-companion-app.socket
+++ b/data/eos-companion-app.socket
@@ -1,7 +1,7 @@
 [Unit]
 Description=EOS Companion App Service
 Wants=network.target
-ConditionPathExists=/var/lib/eos-companion-app/enabled
+ConditionPathExists=/etc/avahi/services/companion-app.service
 
 [Socket]
 ListenStream=1110


### PR DESCRIPTION
We were checking /var/lib/eos-companion-app/enabled, which is
no longer relevant.

https://phabricator.endlessm.com/T20391