### PR TITLE
T20964: Also start/stop the eos-companion-app.socket unit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,7 @@ girdir = $(datadir)/gir-1.0
 gir_DATA = 
 typelibdir = $(libdir)/girepository-1.0
 typelib_DATA =
+rulesdir = $(datadir)/polkit-1/rules.d
 systemdserviceunitdir = $(libdir)/systemd/system/
 systemdserviceunit_DATA = 
 # systemsystemunitdir is defined by configure.ac

--- a/Makefile.am.integration.inc
+++ b/Makefile.am.integration.inc
@@ -59,6 +59,15 @@ EXTRA_DIST += \
 	data/com.endlessm.CompanionAppServiceAvahiHelper.conf \
 	$(NULL)
 
+# PolicyKit Rules
+rules_DATA = \
+	data/com.endlessm.CompanionAppServiceAvahiHelper.rules \
+	$(NULL)
+
+EXTRA_DIST += \
+	data/com.endlessm.CompanionAppServiceAvahiHelper.rules \
+	$(NULL)
+
 # systemd service for the Avahi Helper, Companion App Service and Configuration
 # Manager
 systemdsystemunit_DATA += \

--- a/data/com.endlessm.CompanionAppServiceAvahiHelper.rules
+++ b/data/com.endlessm.CompanionAppServiceAvahiHelper.rules
@@ -1,0 +1,8 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.systemd1.manage-units" &&
+        action.lookup('unit') == 'eos-companion-app.socket' &&
+        (action.lookup('verb') == 'start' || action.lookup('verb') == 'stop') &&
+        subject.user == "companion-app-helper") {
+            return polkit.Result.YES;
+    }
+});

--- a/debian/eos-companion-app-os-integration.install
+++ b/debian/eos-companion-app-os-integration.install
@@ -4,4 +4,5 @@ debian/eos-companion-app-os-integration/usr/lib/*/eos-companion-app-configuratio
 debian/eos-companion-app-os-integration/usr/share/dbus-1/system.d/com.endlessm.CompanionAppServiceAvahiHelper.conf
 debian/eos-companion-app-os-integration/usr/share/dbus-1/system-services/com.endlessm.CompanionAppServiceAvahiHelper.service
 debian/eos-companion-app-os-integration/usr/share/eos-companion-app/config.ini
+debian/eos-companion-app-os-integration/usr/share/polkit-1/rules.d/com.endlessm.CompanionAppServiceAvahiHelper.rules
 debian/eos-companion-app-os-integration/usr/lib/tmpfiles.d/*

--- a/helper/eos-companion-app-avahi-helper
+++ b/helper/eos-companion-app-avahi-helper
@@ -110,6 +110,19 @@ def _remove_avahi_service_file():
             raise error
 
 
+def _systemd_dbus_manage_unit(method, unit, mode):
+    '''Make a call on org.freedesktop.systemd1 to manage a unit file.'''
+    connection = Gio.bus_get_sync(Gio.BusType.SYSTEM)
+    return connection.call_sync('org.freedesktop.systemd1',
+                                '/org/freedesktop/systemd1',
+                                'org.freedesktop.systemd1.Manager',
+                                method,
+                                GLib.Variant('(ss)', (unit, mode)),
+                                GLib.VariantType('(o)'),
+                                Gio.DBusCallFlags.NONE,
+                                -1,
+                                None)
+
 class CompanionAppAvahiHelperSkeleton(EosCompanionAppAvahiHelper.AvahiHelperSkeleton):
     '''Subclass that handles AvahiHelperSkeleton methods and properties.'''
 
@@ -126,6 +139,9 @@ class CompanionAppAvahiHelperSkeleton(EosCompanionAppAvahiHelper.AvahiHelperSkel
             if _can_enable_avahi_discoverability():
                 _write_service_metadata(_read_machine_id())
                 _write_config_file(True)
+                _systemd_dbus_manage_unit('StartUnit',
+                                          'eos-companion-app.socket',
+                                          'replace')
 
                 # XXX: It seems like we have to explicitly set the property
                 # here in order for the PropertiesChanged signal to be emitted
@@ -168,6 +184,9 @@ class CompanionAppAvahiHelperSkeleton(EosCompanionAppAvahiHelper.AvahiHelperSkel
         try:
             _remove_avahi_service_file()
             _write_config_file(False)
+            _systemd_dbus_manage_unit('StopUnit',
+                                      'eos-companion-app.socket',
+                                      'replace')
             self.set_property('discoverable', False)
             self.notify('discoverable')
             self.complete_exit_discoverable_mode(invocation)


### PR DESCRIPTION
We needed to add some new polkit rules to allow the companion-app-helper
user to do this without unnecessary polkit prompts

https://phabricator.endlessm.com/T20964