### PR TITLE
T20963: Take inhibit lock to prevent idle-suspend when active

### DIFF
--- a/Makefile.am.integration.inc
+++ b/Makefile.am.integration.inc
@@ -61,10 +61,12 @@ EXTRA_DIST += \
 
 # PolicyKit Rules
 rules_DATA = \
+	data/com.endlessm.CompanionAppService.rules \
 	data/com.endlessm.CompanionAppServiceAvahiHelper.rules \
 	$(NULL)
 
 EXTRA_DIST += \
+	data/com.endlessm.CompanionAppService.rules \
 	data/com.endlessm.CompanionAppServiceAvahiHelper.rules \
 	$(NULL)
 

--- a/com.endlessm.CompanionAppService.json.in
+++ b/com.endlessm.CompanionAppService.json.in
@@ -7,6 +7,7 @@
     "finish-args": [
         "--share=ipc",
         "--system-talk-name=org.freedesktop.Avahi",
+        "--system-talk-name=org.freedesktop.login1",
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--filesystem=/var/lib/flatpak:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",

--- a/data/com.endlessm.CompanionAppService.rules
+++ b/data/com.endlessm.CompanionAppService.rules
@@ -1,0 +1,7 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.login1.inhibit-block-idle" &&
+        subject.user == "companion-app-helper") {
+            polkit.log('Allowing companion-app-helper to block idle');
+            return polkit.Result.YES;
+    }
+});

--- a/debian/eos-companion-app-os-integration.install
+++ b/debian/eos-companion-app-os-integration.install
@@ -4,5 +4,6 @@ debian/eos-companion-app-os-integration/usr/lib/*/eos-companion-app-configuratio
 debian/eos-companion-app-os-integration/usr/share/dbus-1/system.d/com.endlessm.CompanionAppServiceAvahiHelper.conf
 debian/eos-companion-app-os-integration/usr/share/dbus-1/system-services/com.endlessm.CompanionAppServiceAvahiHelper.service
 debian/eos-companion-app-os-integration/usr/share/eos-companion-app/config.ini
+debian/eos-companion-app-os-integration/usr/share/polkit-1/rules.d/com.endlessm.CompanionAppService.rules
 debian/eos-companion-app-os-integration/usr/share/polkit-1/rules.d/com.endlessm.CompanionAppServiceAvahiHelper.rules
 debian/eos-companion-app-os-integration/usr/lib/tmpfiles.d/*


### PR DESCRIPTION
This will prevent the system from automatically going to sleep
or shutting down whilst the Companion App Service is running. The
service now inserts a new header, X-Endless-Alive-For-Further,
into all responses indicating the number of milliseconds from
the completion of the response that the server is guaranteed,
provided no user intervention or power management failures to stick
around for.

The lock will be automatically released when the process goes
away, since fds are automatically closed when processes exit.

A new policykit rule was also added to explicitly permit
the companion-app-helper to inhibit suspend.

If the client wants the server to stick around for longer, it can make a
request to `/heartbeat` which will extend the deadline.

https://phabricator.endlessm.com/T20963