### PR TITLE
eoscompanion: Inhibit sleep, not idle

### DIFF
--- a/eoscompanion/main.py
+++ b/eoscompanion/main.py
@@ -1458,7 +1458,7 @@ def _inhibit_auto_idle(connection, fd_callback):
                                       # XXX: These strings will need to be
                                       # localized at some point
                                       GLib.Variant('(ssss)',
-                                                   ('idle',
+                                                   ('sleep',
                                                     'Content Sharing',
                                                     'Content is being shared with another device',
                                                     'block')),


### PR DESCRIPTION
I think this is the reason why the computer was going to sleep anyway
even though the inhibtor lock worked fine.

https://phabricator.endlessm.com/T20963