### PR TITLE
config: Use "true", not "True"

### DIFF
--- a/data/config.ini
+++ b/data/config.ini
@@ -1,2 +1,2 @@
 [Companion App]
-enabled=True
+enabled=true


### PR DESCRIPTION
Boolean values in config files are case sensitive, thanks to
Will Thompson for spotting.

https://phabricator.endlessm.com/T20668