### PR TITLE
polkit: Allow inhibit-block-shutdown too

### DIFF
--- a/data/com.endlessm.CompanionAppService.rules
+++ b/data/com.endlessm.CompanionAppService.rules
@@ -1,7 +1,11 @@
 polkit.addRule(function(action, subject) {
-    if (action.id == "org.freedesktop.login1.inhibit-block-idle" &&
+    /* If the app is running as a systemd service, for some reason
+     * the inhibit-block-shutdown permission is requested instead of
+     * inhibit-block-sleep. */
+    if ((action.id == "org.freedesktop.login1.inhibit-block-shutdown" ||
+         action.id == "org.freedesktop.login1.inhibit-block-sleep") &&
         subject.user == "companion-app-helper") {
-            polkit.log('Allowing companion-app-helper to block idle');
+            polkit.log('Allowing companion-app-helper to block idle sleep');
             return polkit.Result.YES;
     }
 });


### PR DESCRIPTION
For some reason, if the service is running through systemd socket activation
and not as a regular user, it requests the inhibit-block-shutdown permission
instead of inhibit-block-sleep, regardless of the fact that we asked for
a sleep inhibitor.

It isn't clear why this is, but if we allow the shutdown inhibitor on
the polkit side, everything works.

https://phabricator.endlessm.com/T20963