### PR TITLE
systemd: Launch com.endlessm.CompanionAppService through dbus-launch

### DIFF
--- a/data/eos-companion-app.service
+++ b/data/eos-companion-app.service
@@ -4,7 +4,7 @@ After=network.target
 ConditionPathExists=/etc/avahi/services/companion-app.service
 
 [Service]
-ExecStart=/usr/bin/flatpak run --no-desktop com.endlessm.CompanionAppService
+ExecStart=/usr/bin/dbus-run-session /usr/bin/flatpak run --no-desktop --no-a11y-bus com.endlessm.CompanionAppService
 User=companion-app-helper
 PrivateTmp=yes
 SystemCallArchitectures=native


### PR DESCRIPTION
This will give us access to a private session bus where we can
dbus-activate EknServices. We also have to launch the a11y
daemons ourselves, otherwise flatpak will try to dbus-autostart
them, which takes a very long time.

https://phabricator.endlessm.com/T21429