### PR TITLE
ekn_url_rewriter: strip way any path before the actual id

### DIFF
--- a/eoscompanion/content_adjusters.py
+++ b/eoscompanion/content_adjusters.py
@@ -26,7 +26,7 @@ from .format import (
     rewrite_ekn_url
 )
 
-_RE_EKN_URL_CAPTURE = re.compile(r'"ekn\:\/\/\/(?P<id>[a-z0-9]+)"')
+_RE_EKN_URL_CAPTURE = re.compile(r'"ekn\:\/\/[a-z0-9\-_\.\\\/]*\/(?P<id>[a-z0-9]+)"')
 
 
 def ekn_url_rewriter(query):


### PR DESCRIPTION
Encyclopedia content had a path before the actual id e.g.
ekn://encyclopedia-en/907a0a35c539f35ff88aae72d1711c07871f4f04,
this fiy makes sure we do rewrite those urls as well.

https://phabricator.endlessm.com/T21753