### PR TITLE
List applications endpoint: blacklist com.endlessm.encyclopedia.*

### DIFF
--- a/src/eos-companion-app-integration-helper.c
+++ b/src/eos-companion-app-integration-helper.c
@@ -34,6 +34,7 @@
 
 #define SUPPORTED_RUNTIME_NAME "com.endlessm.apps.Platform"
 #define SUPPORTED_RUNTIME_BRANCH "3"
+#define ENCYCLOPEDIA_APP_PREFIX "com.endlessm.encyclopedia."
 
 /* Needed to get autocleanups of GResource files */
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GResource, g_resource_unref)
@@ -498,6 +499,10 @@ list_application_infos (GCancellable  *cancellable,
            * it is using */
           if (!examine_flatpak_metadata (flatpak_directory, &app_name, &runtime_name, error))
             return NULL;
+
+	  /* Blacklist com.endlessm.encyclopedia.* */
+          if (g_str_has_prefix (app_name, ENCYCLOPEDIA_APP_PREFIX))
+            continue;
 
           /* Check if the application is an eligible content app */
           if (!app_is_compatible (app_name, runtime_name, &is_compatible_app, error))


### PR DESCRIPTION
The encyclopedia content is not structured to be displayed
in the categories view, nor can we display all the available
articles in one list.

Until the app is restructured blacklist it from the
application list.

The encyclopedia articles can still be accessed from
the search.

https://phabricator.endlessm.com/T21042