### PR TITLE
List applications endpoint: blacklist com.endlessm.encyclopedia.*

### DIFF
--- a/eoscompanion/routes.py
+++ b/eoscompanion/routes.py
@@ -180,6 +180,10 @@ def companion_app_server_list_applications_route(server, msg, path, query, *args
 
     def _callback(applications):
         '''Callback function that gets called when we are done.'''
+
+        # Blacklist com.endlessm.encyclopedia.*
+        filtered_applications = (application for application in applications if 'com.endlessm.encyclopedia.' not in application.app_id)
+
         json_response(msg, {
             'status': 'ok',
             'payload': [
@@ -190,7 +194,7 @@ def companion_app_server_list_applications_route(server, msg, path, query, *args
                     'icon': format_app_icon_uri(a.icon, query['deviceUUID']),
                     'language': a.language
                 }
-                for a in applications
+                for a in filtered_applications
             ]
         })
         server.unpause_message(msg)

--- a/src/eos-companion-app-integration-helper.c
+++ b/src/eos-companion-app-integration-helper.c
@@ -34,7 +34,6 @@
 
 #define SUPPORTED_RUNTIME_NAME "com.endlessm.apps.Platform"
 #define SUPPORTED_RUNTIME_BRANCH "3"
-#define ENCYCLOPEDIA_APP_PREFIX "com.endlessm.encyclopedia."
 
 /* Needed to get autocleanups of GResource files */
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GResource, g_resource_unref)
@@ -499,10 +498,6 @@ list_application_infos (GCancellable  *cancellable,
            * it is using */
           if (!examine_flatpak_metadata (flatpak_directory, &app_name, &runtime_name, error))
             return NULL;
-
-	  /* Blacklist com.endlessm.encyclopedia.* */
-          if (g_str_has_prefix (app_name, ENCYCLOPEDIA_APP_PREFIX))
-            continue;
 
           /* Check if the application is an eligible content app */
           if (!app_is_compatible (app_name, runtime_name, &is_compatible_app, error))


### PR DESCRIPTION
The encyclopedia content is not structured to be displayed
in the categories view, nor can we display all the available
articles in one list.

Until the app is restructured blacklist it from the
application list.

The encyclopedia articles can still be accessed from
the search.

Fix for a713ef01caf48a4b5b9db9dd7709ad4a1d57ba30

https://phabricator.endlessm.com/T21042