### PR TITLE
readme: Remove API Key warning

### DIFF
--- a/README
+++ b/README
@@ -64,9 +64,3 @@ wants those dependencies to be installed in the systemwide flatpak installation
 so we have an extra tool to regenerate the flatpak pip manifest to include those
 requirements at build-time and test-time and then clean them up afterwards. To
 run that tool, just use `make regenerate-pip-manifest-template`.
-
-## WARNING
-
-This repo history contained a GitHub API key in
-com.endlessm.CompanionAppService.json.in, it should be removed before the
-repository is made public!!


### PR DESCRIPTION
It looks like this repository was made public before we had a chance to edit the history and remove the API key. In any event, that key is no longer in use, so this warning is pretty useless now.