### PR TITLE
flatpak: remove basin

### DIFF
--- a/com.endlessm.CompanionAppService.json.in
+++ b/com.endlessm.CompanionAppService.json.in
@@ -25,16 +25,6 @@
     "modules": [
         "com.endlessm.CompanionAppService.PipDependencies.json",
         {
-            "name": "basin",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/endlessm/basin",
-                    "branch": "T21272-patch"
-                }
-            ]
-        },
-        {
             "name": "mustache-c",
             "sources": [
                 {


### PR DESCRIPTION
In the tests we removed content shard building code, so we do not need the fork of basin that supports "path"
any more.