### PR TITLE
Splice operation on file failed: set log level to debug

### DIFF
--- a/eoscompanion/routes.py
+++ b/eoscompanion/routes.py
@@ -870,7 +870,7 @@ def companion_app_server_content_data_route(server,
                     src.splice_finish(result)
                 except GLib.Error as splice_error:
                     # Can't really do much here except log server side
-                    logging.warning(
+                    logging.debug(
                         'Splice operation on file failed: %s', splice_error
                     )
 


### PR DESCRIPTION
This happends when client closes the connection before we
transferred all of the buffer. Since we switch to partial
requests at the beginning of each transfer this is logged
often. No need to log in non-debug case.

https://phabricator.endlessm.com/T22557