### PR TITLE
src: Specify the systemd socket activation fd through an environment var

### DIFF
--- a/data/eos-companion-app.service
+++ b/data/eos-companion-app.service
@@ -33,3 +33,4 @@ SystemCallErrorNumber=EPERM
 SystemCallArchitectures=native
 Environment="XDG_RUNTIME_DIR=/tmp/run"
 Environment="XDG_DATA_DIRS=/var/lib/flatpak/exports/share:/var/endless-extra/flatpak/exports/share"
+Environment="EOS_COMPANION_APP_SERVICE_STARTED_BY_SYSTEMD=1"


### PR DESCRIPTION
We can't get this from wthin flatpak as it would require linking
to systemd itself and assuming that the file descriptor is
always "3" causes problems when launching from outside of systemd
(as other sockets may have been opened by GAppliction which
have this file descriptor, causing libsoup to choke).

Ideally, we would proxy it through a subprocess and detect it using the systemd API, but that does not seem to work, see https://github.com/endlessm/eos-companion-app-integration/tree/T23616-wrapper .

https://phabricator.endlessm.com/T23616