### PR TITLE
debian: Remove install file

### DIFF
--- a/debian/eos-companion-app-os-integration.install
+++ b/debian/eos-companion-app-os-integration.install
@@ -1,9 +1,0 @@
-debian/eos-companion-app-os-integration/lib/systemd/system/*
-debian/eos-companion-app-os-integration/usr/lib/*/eos-companion-app-avahi-helper
-debian/eos-companion-app-os-integration/usr/lib/*/eos-companion-app-configuration-manager
-debian/eos-companion-app-os-integration/usr/share/dbus-1/system.d/com.endlessm.CompanionAppServiceAvahiHelper.conf
-debian/eos-companion-app-os-integration/usr/share/dbus-1/system-services/com.endlessm.CompanionAppServiceAvahiHelper.service
-debian/eos-companion-app-os-integration/usr/share/eos-companion-app/config.ini
-debian/eos-companion-app-os-integration/usr/share/polkit-1/rules.d/com.endlessm.CompanionAppService.rules
-debian/eos-companion-app-os-integration/usr/share/polkit-1/rules.d/com.endlessm.CompanionAppServiceAvahiHelper.rules
-debian/eos-companion-app-os-integration/usr/lib/tmpfiles.d/*


### PR DESCRIPTION
This was causing the files to literally be installed as
/debian/eos-companion-app-integration/<path>. For a single binary
package, an install file is not needed unless the files need to be
filtered in some way, and that's not the case here.

What was happening was that dh_install installs paths with its own
search path prefixes stripped. It was being told to install the files
found at debian/eos-companion-app-integration to /. In a multi package
setup, dh_auto_install would install to debian/tmp and then dh_install
would split that up to the output debian/<package-N> directories. In
that case, you wouldn't even have files at debian/<package-N> when
dh_install runs. However, in the single package case, dh_auto_install
tries to help you out by installing directly to the debian/<package>
output directory. In that case, you don't need an install file at all.

https://phabricator.endlessm.com/T23862