### PR TITLE
Clean up static libraries and libtool archives

### DIFF
--- a/com.endlessm.CompanionAppService.json.in
+++ b/com.endlessm.CompanionAppService.json.in
@@ -27,6 +27,10 @@
         "--share=network",
         "--command=eos-companion-app-service"
     ],
+    "cleanup": [
+        "*.a",
+        "*.la"
+    ],
     "modules": [
         "com.endlessm.CompanionAppService.PipDependencies.json",
         {


### PR DESCRIPTION
These are not used at runtime, and account for 85% (43MB) of the
installed app's size (50MB):

```
$ du -shx ~/.local/share/flatpak/app/com.endlessm.CompanionAppService/ /var/lib/flatpak/app/com.endlessm.CompanionAppService/
7.2M	/sysroot/home/wjt/.local/share/flatpak/app/com.endlessm.CompanionAppService/
50M	/var/lib/flatpak/app/com.endlessm.CompanionAppService/
```

Most of this is libsass.a:

```
$ find /var/lib/flatpak/app/com.endlessm.CompanionAppService/current/active/ -type f | xargs ls -lSrh | tail -n5
-rwxr-xr-x    2 root root  79K Jan  1  1970 /var/lib/flatpak/app/com.endlessm.CompanionAppService/current/active/files/lib/libeknr-0.so.0.0.0
-rwxr-xr-x    2 root root 158K Jan  1  1970 /var/lib/flatpak/app/com.endlessm.CompanionAppService/current/active/files/lib/libendless-0.so.0.500.0
-rw-r--r--    2 root root 390K Jan  1  1970 /var/lib/flatpak/app/com.endlessm.CompanionAppService/current/active/files/lib/libeos-shard-0.a
-rwxr-xr-x    2 root root 2.5M Jan  1  1970 /var/lib/flatpak/app/com.endlessm.CompanionAppService/current/active/files/lib/libsass.so.0.0.9
-rw-r--r--    2 root root  42M Jan  1  1970 /var/lib/flatpak/app/com.endlessm.CompanionAppService/current/active/files/lib/libsass.a
```

https://phabricator.endlessm.com/T25970